### PR TITLE
auto-gen changelog in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,5 @@ jobs:
         with:
           files: Resume.pdf
           body_path: CHANGELOG.md
-          body: Changelog unavailable.
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,6 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           files: Resume.pdf
-          body_path: CHANGELOG.md
+          body_path: ${{ github.workspace }}/CHANGELOG.md
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,9 +15,15 @@ jobs:
         uses: xu-cheng/latex-action@v2
         with:
           root_file: Resume.tex
+      - name: Changelog
+        uses: charmixer/auto-changelog-action@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
       - name: Release
         uses: softprops/action-gh-release@v1
         with:
           files: Resume.pdf
+          body_path: CHANGELOG.md
+          body: Changelog unavailable.
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Use [auto-changelog-action](https://github.com/charmixer/auto-changelog-action) to generate changelog on release.